### PR TITLE
Allow Stacking Scripted Entities 

### DIFF
--- a/lua/improvedstacker/localization.lua
+++ b/lua/improvedstacker/localization.lua
@@ -73,6 +73,7 @@ localify.Bind( "en", prefix.."checkbox_axis",            "Draw XYZ axis" )
 localify.Bind( "en", prefix.."checkbox_axis_labels",     "Draw XYZ axis labels" )
 localify.Bind( "en", prefix.."checkbox_axis_angles",     "Draw XYZ axis angles" )
 localify.Bind( "en", prefix.."checkbox_stayinworld",     "Stay in world" )
+localify.Bind( "en", prefix.."checkbox_allow_sents",     "Allow Stackable Sents" )
 -- Comboboxes
 localify.Bind( "en", prefix.."combobox_world",           "World" )
 localify.Bind( "en", prefix.."combobox_prop",            "Prop" )


### PR DESCRIPTION
Small modification to enable stackable scripted entities.

- the convar **_force_allow_sents** must be enabled on the server
- the entity's table must have **.Stackable** set to **true**

There is a slight problem regarding entity limits (not all scripted entities are meant to count against 'sents') but it shouldn't be a hindrance unless maxsents is set to something really low on the server. 